### PR TITLE
Updated to use CDN URLs for Visual Framework

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,11 +15,11 @@
 -->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <!-- Your custom JavaScript file scan go here... change names accordingly -->
-<script defer="defer" src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/js/script.js"></script>
+<script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/js/script.js"></script>
 
 <!-- The Foundation theme JavaScript -->
-<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/js/foundation.js"></script>
-<script src="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/js/foundationExtendEBI.js"></script>
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/js/foundation.js"></script>
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/js/foundationExtendEBI.js"></script>
 <script type="text/JavaScript">$(document).foundation();</script>
 <script type="text/JavaScript">$(document).foundationExtendEBI();</script>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,9 +24,9 @@
 
   <!-- CSS: implied media=all -->
   <!-- CSS concatenated and minified via ant build script-->
-  <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css" type="text/css" media="all">
-  <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css" type="text/css" media="all">
-  <link rel="stylesheet" href="//www.ebi.ac.uk/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all">
+  <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/libraries/foundation-6/css/foundation.css" type="text/css" media="all">
+  <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.2/css/ebi-global.css" type="text/css" media="all">
+  <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.2/fonts.css" type="text/css" media="all">
   {% comment %} Custom global CSS could go here: {% endcomment %}
   {% for css in site.custom_css %}
   <link rel="stylesheet" href="{{site.baseurl}}{{css}}">


### PR DESCRIPTION
Updated to use CDN URLs for Visual Framework.

Looks like the IMEx team have made some changes, so we should ask how they want to pull these in.

See https://github.com/ebiwd/IMEx-site/network